### PR TITLE
fix: replace action.get_selected_entry with actions_state.get_selected_entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,35 @@ Integration for [vimspector](https://github.com/puremourning/vimspector) with
 
 ![Demo](./demo.gif)
 
+# Requirements
+
+* [vimspector](https://github.com/puremourning/vimspector) 
+* [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
+
 # Installation
 
 ```viml
-Plug 'puremourning/vimspector'
-
-Plug 'nvim-lua/popup.nvim'
-Plug 'nvim-lua/plenary.nvim'
-Plug 'nvim-telescope/telescope.nvim'
 Plug 'nvim-telescope/telescope-vimspector.nvim'
 ```
 
+Load the extension by doing:
+
+```viml
+require("telescope").load_extension("vimspector")
+```
+
+somewhere after your require('telescope').setup() call.
+
 # Usage
 
+Fuzzy find over vimspector configurations:
+
 ```lua
--- Fuzzy find over vimspector configurations
 require('telescope').extensions.vimspector.configurations()
+```
+
+or 
+
+```
+:Telescope vimspector configurations
 ```

--- a/lua/telescope/_extensions/vimspector.lua
+++ b/lua/telescope/_extensions/vimspector.lua
@@ -1,4 +1,5 @@
 local actions = require('telescope.actions')
+local actions_state = require('telescope.actions.state')
 local finders = require('telescope.finders')
 local pickers = require('telescope.pickers')
 local sorters = require('telescope.sorters')
@@ -26,15 +27,12 @@ return require('telescope').register_extension {
                 },
                 sorter = sorters.get_generic_fuzzy_sorter(),
                 attach_mappings = function(prompt_bufnr, map)
-                    local start_debugger = function()
-                        local selection = actions.get_selected_entry(prompt_bufnr)
+                    actions.select_default:replace(function()
+                        local selection = actions_state.get_selected_entry()
                         actions.close(prompt_bufnr)
 
                         vim.fn["vimspector#LaunchWithSettings"]({configuration = selection.value})
-                    end
-
-                    map('i', '<CR>', start_debugger)
-                    map('n', '<CR>', start_debugger)
+                    end)
 
                     return true
                 end


### PR DESCRIPTION
Hi,

The extension currently does not work at all. After selecting a configuration you get the following error:

```
5108: Error executing lua ...im/plugged/telescope.nvim/lua/telescope/actions/init.lua:29: Key does not exist for 'telescope.acti
ons': get_selected_entry
```

Apparently that is due to a telescope api change.

This PR fixes it :)